### PR TITLE
Add stylelint-config-rational-order.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - [stylelint](https://github.com/stylelint/stylelint-config-standard) - The standard shareable config for stylelint
 - [Wikimedia](https://github.com/wikimedia/stylelint-config-wikimedia) – Wikimedia CSS Coding Standards shareable config for stylelint
 - [WordPress](https://github.com/ntwb/stylelint-config-wordpress/) – WordPress CSS Coding Standards shareable config for stylelint
+- [rational-order](https://github.com/constverum/stylelint-config-rational-order) - Stylelint config that sorts related property declarations by grouping together in the rational order
 
 ## Formatters
 


### PR DESCRIPTION
Stylelint is awesome.

Having a predetermined order for CSS rules is fairly useful as well for teams who want that, because linting is the only way to ensure this happens. Stylelint-config-rational-order provides a good default order for CSS declarations, saving you from configuring it yourself. For this reason, I thought I would add it to the list.

Please let me know your thoughts.