### PR TITLE
Add stylelint-plugin-rhythmguard

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ A list of awesome Stylelint configs, plugins, integrations etc.
 - [stylelint-declaration-strict-value](https://www.npmjs.com/package/stylelint-declaration-strict-value) - Enforce variables, functions or keywords for the value of specific properties.
 - [stylelint-media-use-custom-media](https://www.npmjs.com/package/stylelint-media-use-custom-media) - Enforce usage of custom media queries.
 - [stylelint-no-restricted-syntax](https://www.npmjs.com/package/stylelint-no-restricted-syntax) - Disallow specified syntax.
+- [stylelint-plugin-rhythmguard](https://www.npmjs.com/package/stylelint-plugin-rhythmguard) - Enforce spacing scales and design token usage across CSS and Tailwind class strings (Pack).
 - [stylelint-scales](https://www.npmjs.com/package/stylelint-scales) - Enforce scales for numeric values (Pack).
 - [stylelint-value-no-unknown-custom-properties](https://www.npmjs.com/package/stylelint-value-no-unknown-custom-properties) - Disallow unknown custom properties.
 


### PR DESCRIPTION
Adds [stylelint-plugin-rhythmguard](https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard) to the Variables and constraints section.

Rhythmguard enforces spacing scales and design token usage across CSS declarations and Tailwind class strings. Three rules: use-scale, prefer-token, no-offscale-transform. All autofix.

- npm: https://www.npmjs.com/package/stylelint-plugin-rhythmguard
- Supports Stylelint 16 and 17
- MIT licensed