### PR TITLE
Add Accessibility section and @a11yfred/stylelint-plugin-neighbor

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ A list of awesome Stylelint configs, plugins, integrations etc.
 
 ## Plugins
 
+### Accessibility
+
+- [@a11yfred/stylelint-plugin-neighbor](https://github.com/a11yfred/neighbor) - Enforces accessibility in CSS, including high-contrast and forced-colors fallbacks.
+
 ### Architecture and methodologies
 
 - [stylelint-plugin-defensive-css](https://www.npmjs.com/package/stylelint-plugin-defensive-css) - Enforce defensive CSS best practices (Pack).


### PR DESCRIPTION
This introduces a new "Accessibility" category to the Plugins list to help developers find CSS-specific a11y tools. It seeds the new section with @a11yfred/stylelint-plugin-neighbor, which enforces high-contrast fallbacks, safe focus states, and motion preferences.

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->
> Which issue, if any, is this issue related to?

None, adding to the `awesome-stylelint` list.

> Is there anything in the PR that needs further explanation?

I noticed that while the `Plugins` list is beautifully categorized, there wasn't a dedicated section for Accessibility. I created the `### Accessibility` heading (placed alphabetically at the top of the subsections) to make it easier for developers to discover CSS-specific a11y tools.