### PR TITLE
Add stylelint-plugin-grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ A list of awesome Stylelint configs, plugins, integrations etc.
 - [stylelint-react-native](https://www.npmjs.com/package/stylelint-react-native) - Enforce React Native rules (Pack).
 - [stylelint-selector-bem-pattern](https://www.npmjs.com/package/stylelint-selector-bem-pattern) - Enforce BEM patterns for selectors.
 - [@morev/stylelint-plugin](https://www.npmjs.com/package/@morev/stylelint-plugin) - Enforce (S)CSS and BEM best practices (Pack).
+- [stylelint-plugin-grid](https://www.npmjs.com/package/stylelint-plugin-grid) - Enforce CSS Grid correctness, safe grid patterns and layout bug prevention.
 
 ### Browser compatibility
 


### PR DESCRIPTION
Adds stylelint-plugin-grid to the relevant Plugins section.

Repository: https://github.com/Nick2bad4u/stylelint-plugin-grid

Validation:
- `npx awesome-lint README.md`